### PR TITLE
jinja templating

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
         "snowflake-connector-python",
         "slack_sdk",
         "boto3",
+        "jinja2<3.0.0",
     ],
     entry_points={
         "console_scripts": [

--- a/src/dbtease/common.py
+++ b/src/dbtease/common.py
@@ -1,7 +1,9 @@
 """Common framework for loading yaml files."""
 
 import yaml
+import os
 import os.path
+from typing import Optional
 
 from jinja2.sandbox import SandboxedEnvironment
 
@@ -18,13 +20,28 @@ class YamlFileObject:
             "from_dict method not overriden for {0}".format(cls.__name__)
         )
 
+    @staticmethod
+    def env_var(var: str, default: Optional[str] = None) -> str:
+        """The env_var() function. Return the environment variable named 'var'.
+        If there is no such environment variable set, return the default.
+        If the default is None, raise an exception for an undefined variable.
+
+        This is modified directly from: https://github.com/fishtown-analytics/dbt/blob/cee0bfbfa2596520032b766fd1027fe748777c75/core/dbt/context/base.py#L275
+        """
+        if var in os.environ:
+            return os.environ[var]
+        elif default is not None:
+            return default
+        else:
+            raise ValueError(f"Env var required but not provided: '{var}'")
+
     @classmethod
     def _template_string(cls, raw_string: str) -> str:
         """Render a jinja templated string.
 
         Reference for macros: https://github.com/fishtown-analytics/dbt/blob/cee0bfbfa2596520032b766fd1027fe748777c75/core/dbt/context/base.py#L275
         """
-        jinja_context: dict = {}
+        jinja_context: dict = {"env_var": cls.env_var}
 
         jinja_env = SandboxedEnvironment(
             # The do extension allows the "do" directive

--- a/src/dbtease/schedule.py
+++ b/src/dbtease/schedule.py
@@ -215,7 +215,9 @@ class DbtSchedule(YamlFileObject):
             # Get the details of the target from the profiles file if not provided.
             if not target_dict:
                 # First precedence is override, then file config, then default.
-                profiles_dir = profiles_dir or kwargs.get("dbt_profiles_path", None) or "~/.dbt/"
+                profiles_dir = (
+                    profiles_dir or kwargs.get("dbt_profiles_path", None) or "~/.dbt/"
+                )
                 # TODO: Probably needs much more exception handling.
                 # TODO: Deal with jinja templating too.
                 profiles = DbtProfiles.from_path(

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -1,0 +1,37 @@
+"""Test the common yaml loader."""
+
+import pytest
+
+from dbtease.common import YamlFileObject
+
+
+class DummyFileObject(YamlFileObject):
+    """A test object."""
+    def __init__(self, obj):
+        self.obj = obj
+
+    @classmethod
+    def from_dict(cls, config, **kwargs):
+        """Make an object holding a dict."""
+        return cls(obj=config)
+
+
+def test__simple_yaml_load():
+    """Test loading a simple yaml string."""
+    test_string = "foo: bar"
+    test_obj = DummyFileObject.from_string(test_string)
+    assert isinstance(test_obj, DummyFileObject)
+    assert test_obj.obj == {"foo": "bar"}
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("foo", "foo"),
+        ("some{# comment #}thing", "something"),
+        ("{% for elem in ['foo', 'bar']%}{{elem}}{% endfor %}", "foobar"),
+    ]
+)
+def test__common_jinja_template(test_input, expected):
+    """Test jinja rendering."""
+    assert YamlFileObject._template_string(test_input) == expected

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -30,6 +30,8 @@ def test__simple_yaml_load():
         ("foo", "foo"),
         ("some{# comment #}thing", "something"),
         ("{% for elem in ['foo', 'bar']%}{{elem}}{% endfor %}", "foobar"),
+        # This assumes that SOME_ENV_VALUE doesn't actually exist.
+        ("{{ env_var('SOME_ENV_VALUE', default='baz') }}", "baz"),
     ]
 )
 def test__common_jinja_template(test_input, expected):


### PR DESCRIPTION
Enable Jinja templating in Yaml files. The only context value available for now is `env_var` with an implementation borrowed heavily from dbt. Finally adds some test coverage for this too!